### PR TITLE
feat(54623266): add invitation logic on mocks

### DIFF
--- a/packages/pages.invites/src/mocks.ts
+++ b/packages/pages.invites/src/mocks.ts
@@ -1,18 +1,50 @@
-import { MockInviteT } from './types';
+import { InviteT } from './types';
 
-export const mockInvites: MockInviteT[] = [
-  {
-    id: '1',
-    type: 'group',
-    name: 'Practice English',
-    info: '4 человека',
-    avatarUrl: '',
+export const mockInviteData: Record<string, InviteT> = {
+  // Индивидуальное приглашение (новое), кейс: репетитор переходит на приглашение в собственнный кабинет
+  '1': {
+    kind: 'individual',
+    tutor: {
+      user_id: 1,
+      username: 'a.demidov',
+      display_name: 'Андрей Демидов',
+    },
+    existing_classroom_id: null,
   },
-  {
-    id: '2',
-    type: 'tutor',
-    name: 'Андрей Демидов',
-    info: 'a.demidov',
-    avatarUrl: '',
+  // Индивидуальное приглашение (уже принято)
+  '2': {
+    kind: 'individual',
+    tutor: {
+      user_id: 2,
+      username: 'english.tutor',
+      display_name: 'Английский с репетитором',
+    },
+    existing_classroom_id: 2,
   },
-];
+  // Групповое приглашение (новое)
+  '3': {
+    kind: 'group',
+    tutor: {
+      user_id: 3,
+      username: 'group.master',
+      display_name: 'Мастер групп',
+    },
+    classroom: {
+      name: 'Advanced English Group',
+    },
+    has_already_joined: false,
+  },
+  // Групповое приглашение (уже принято)
+  '4': {
+    kind: 'group',
+    tutor: {
+      user_id: 4,
+      username: 'practice.english',
+      display_name: 'Practice English',
+    },
+    classroom: {
+      name: 'Intermediate English',
+    },
+    has_already_joined: true,
+  },
+};

--- a/packages/pages.invites/src/services/index.ts
+++ b/packages/pages.invites/src/services/index.ts
@@ -1,0 +1,2 @@
+export { useInvitePreview } from './useInvitePreview';
+export { useAcceptInvite } from './useAcceptInvite';

--- a/packages/pages.invites/src/services/useAcceptInvite.tsx
+++ b/packages/pages.invites/src/services/useAcceptInvite.tsx
@@ -1,0 +1,44 @@
+import { useMutation } from '@tanstack/react-query';
+import { ClassroomResponseT } from '../types';
+import { mockInviteData } from '../mocks';
+import { useNavigate } from '@tanstack/react-router';
+
+export const useAcceptInvite = () => {
+  const navigate = useNavigate();
+
+  return useMutation<ClassroomResponseT, Error, string>({
+    mutationFn: async (code: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const invite = mockInviteData[code];
+
+      if (invite.kind === 'individual') {
+        return {
+          kind: 'individual',
+          id: 2,
+          status: 'active',
+          created_at: new Date().toISOString(),
+          description: null,
+          tutor_id: invite.tutor.user_id,
+          name: invite.tutor.username,
+        };
+      } else {
+        return {
+          kind: 'group',
+          id: 2,
+          status: 'active',
+          created_at: new Date().toISOString(),
+          description: null,
+          tutor_id: invite.tutor.user_id,
+          name: invite.classroom.name,
+        };
+      }
+    },
+    onSuccess: (classroomData) => {
+      navigate({ to: `/classrooms/${classroomData.id}` });
+    },
+    onError: (error) => {
+      console.error('Ошибка:', error.message);
+    },
+  });
+};

--- a/packages/pages.invites/src/services/useInvitePreview.tsx
+++ b/packages/pages.invites/src/services/useInvitePreview.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { mockInviteData } from '../mocks';
+import { InviteT } from '../types';
+
+export const useInvitePreview = (code: string) => {
+  return useQuery<InviteT, Error>({
+    queryKey: ['preview', code],
+    queryFn: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      const invite = mockInviteData[code];
+
+      if (!invite) {
+        throw new Error('Приглашение не найдено');
+      }
+
+      if (code === '1') {
+        throw new Error('Target is the source');
+      }
+
+      return invite;
+    },
+    enabled: !!code,
+    retry: false,
+  });
+};

--- a/packages/pages.invites/src/types.ts
+++ b/packages/pages.invites/src/types.ts
@@ -1,7 +1,46 @@
-export type MockInviteT = {
-  id: string;
-  type: 'group' | 'tutor';
-  name: string;
-  info: string;
-  avatarUrl?: string;
+export type TutorInfoT = {
+  user_id: number;
+  username: string;
+  display_name: string | null;
 };
+
+export type IndividualInvitation = {
+  kind: 'individual';
+  tutor: TutorInfoT;
+  existing_classroom_id: number | null;
+};
+
+export type GroupInfoT = {
+  name: string;
+};
+
+export type GroupInvitation = {
+  kind: 'group';
+  tutor: TutorInfoT;
+  classroom: GroupInfoT;
+  has_already_joined: boolean;
+};
+
+export type InviteT = IndividualInvitation | GroupInvitation;
+
+export type IndividualClassroomResponseT = {
+  kind: 'individual';
+  id: number;
+  status: string;
+  created_at: string;
+  description: string | null;
+  tutor_id: number;
+  name: string;
+};
+
+export type GroupClassroomResponseT = {
+  kind: 'group';
+  id: number;
+  status: string;
+  created_at: string;
+  description: string | null;
+  tutor_id: number;
+  name: string;
+};
+
+export type ClassroomResponseT = IndividualClassroomResponseT | GroupClassroomResponseT;

--- a/packages/pages.invites/src/ui/ErrorInvite.tsx
+++ b/packages/pages.invites/src/ui/ErrorInvite.tsx
@@ -1,8 +1,31 @@
-export const ErrorInvite = () => {
+interface ErrorInviteProps {
+  error: Error | string;
+}
+
+export const ErrorInvite = ({ error }: ErrorInviteProps) => {
+  const getErrorMessage = () => {
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (error.message === 'Target is the source') {
+      return 'Преподаватель не может принять собственное приглашение';
+    }
+
+    return error.message || 'Приглашение недействительно';
+  };
+
+  const getErrorDescription = () => {
+    if (error instanceof Error && error.message === 'Target is the source') {
+      return 'Вы не можете присоединиться к собственному кабинету';
+    }
+    return 'Обратитесь к репетитору за новым приглашением';
+  };
+
   return (
     <div className="flex w-full flex-col gap-4 p-8 text-center sm:w-[400px]">
-      <h4 className="text-xl-base font-semibold">Приглашение недействительно :(</h4>
-      <span>Обратитесь к репетитору за новым приглашением</span>
+      <h4 className="text-xl-base font-semibold">{getErrorMessage()}</h4>
+      <span>{getErrorDescription()}</span>
     </div>
   );
 };

--- a/packages/pages.invites/src/ui/Invite.tsx
+++ b/packages/pages.invites/src/ui/Invite.tsx
@@ -1,29 +1,60 @@
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { Avatar, AvatarFallback, AvatarImage } from '@xipkg/avatar';
 import { Button } from '@xipkg/button';
-import { MockInviteT } from '../types';
+import { InviteT } from '../types';
+import { useAcceptInvite } from '../services';
 
-export const Invite = ({ invite }: { invite: MockInviteT }) => {
+export const Invite = ({ invite }: { invite: InviteT }) => {
   const navigate = useNavigate();
+  const { inviteId } = useParams({ strict: false });
+  const { mutate } = useAcceptInvite();
+
+  const isInviteAccepted =
+    (invite.kind === 'individual' && invite.existing_classroom_id) ||
+    (invite.kind === 'group' && invite.has_already_joined);
+
+  const getInviteTitle = () =>
+    isInviteAccepted ? 'Приглашение принято' : 'Вы получили приглашение';
+
+  const getAcceptButtonText = () => (isInviteAccepted ? 'Перейти в кабинет' : 'Принять');
+
+  const acceptInvite = () => {
+    if (invite.kind === 'individual' && invite.existing_classroom_id) {
+      navigate({ to: `/classrooms/${invite.existing_classroom_id}` }); // Переход по старому приглашению в индивидуальный кабинет
+    } else if (invite.kind === 'group' && invite.has_already_joined) {
+      // Не хватает ID группы для перехода по приглашению в групповой кабинет
+      // Получаемая информация о группе на данный момент: classromm (name)
+      // ожидается: classroom (id + name + participant_count)
+      // navigate({ to: `/classrooms/${invite.classroom.id}` });
+    } else {
+      mutate(inviteId); // первое принятие приглашения
+    }
+  };
 
   return (
     <div className="flex w-full flex-col gap-8 p-2 sm:w-[500px]">
       <div className="text-center">
-        <h3 className="text-xl-base mb-2 font-semibold">Вы получили приглашение</h3>
-        <span>{invite.type === 'group' ? 'Группа' : 'Репетитор'}</span>
+        <h3 className="text-xl-base mb-2 font-semibold">{getInviteTitle()}</h3>
+        <span>{invite.kind === 'individual' ? 'Репетитор' : 'Группа'}</span>
       </div>
       <div className="flex flex-col items-center gap-2">
         <Avatar size="xl">
-          <AvatarImage src={invite.avatarUrl || ''} alt="user avatar" />
+          <AvatarImage src="" alt="user avatar" />
           <AvatarFallback />
         </Avatar>
         <div className="flex flex-col items-center">
-          <p>{invite.name}</p>
-          <span className="text-s-base">{invite.info}</span>
+          <p>{invite.kind === 'individual' ? invite.tutor.display_name : invite.classroom.name}</p>
+          <span className="text-s-base">
+            {invite.kind === 'individual' ? invite.tutor.username : '4 человека'}
+            {/*должно быть поле invite.classroom.participant_count для группы*/}
+          </span>
         </div>
       </div>
+
       <div className="flex flex-col justify-center gap-2">
-        <Button className="w-full rounded-xl">Принять</Button>
+        <Button className="w-full rounded-xl" onClick={acceptInvite}>
+          {getAcceptButtonText()}
+        </Button>
         <Button onClick={() => navigate({ to: '/' })} className="w-full rounded-xl" variant="ghost">
           Отказаться
         </Button>

--- a/packages/pages.invites/src/ui/InvitesPage.tsx
+++ b/packages/pages.invites/src/ui/InvitesPage.tsx
@@ -1,34 +1,38 @@
 import { Logo } from 'common.ui';
 import { useParams } from '@tanstack/react-router';
-import { mockInvites } from '../mocks';
-import { useEffect, useState } from 'react';
-import { MockInviteT } from '../types';
 import { Invite } from './Invite';
 import { ErrorInvite } from './ErrorInvite';
-
-const mockStatus: 'success' | 'error' = 'success';
-
-async function getData(id: string) {
-  return mockInvites.find((invite) => invite.id === id);
-}
+import { useInvitePreview } from '../services';
 
 export const InvitesPage = () => {
-  const status = mockStatus;
-  const [invite, setInvite] = useState<MockInviteT>();
   const { inviteId } = useParams({ strict: false });
+  const { data, error, isLoading } = useInvitePreview(inviteId);
 
-  useEffect(() => {
-    if (!inviteId) return;
-
-    getData(inviteId).then((mockInvite) => setInvite(mockInvite));
-  }, [inviteId]);
+  if (isLoading) {
+    return (
+      <section className="relative flex h-screen flex-col items-center justify-center">
+        <div className="absolute top-24">
+          <Logo />
+        </div>
+        <div className="flex w-full flex-col items-center gap-4 p-8 sm:w-[400px]">
+          <p>Загрузка приглашения...</p>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="relative flex h-screen flex-col items-center justify-center">
       <div className="absolute top-24">
         <Logo />
       </div>
-      {status === 'success' && invite ? <Invite invite={invite} /> : <ErrorInvite />}
+      {error ? (
+        <ErrorInvite error={error} />
+      ) : data ? (
+        <Invite invite={data} />
+      ) : (
+        <ErrorInvite error="Приглашение не найдено" />
+      )}
     </section>
   );
 };


### PR DESCRIPTION
Нужно уточнить ситуацию, когда студент уже переходил по приглашению (например, вступил в группу). Пока написана логика перехода в этот кабинет, для групп это не работает: в openapi группа содержит только поле name, ожидается: id, name, participant_count