### PR TITLE
127: fix(modules.profile): telegram notification on IOS

### DIFF
--- a/packages/modules.profile/src/services/useConnectTg.ts
+++ b/packages/modules.profile/src/services/useConnectTg.ts
@@ -14,10 +14,15 @@ export const useConnectTg = () => {
   const handleConnectTg = () => {
     if (status === 'active') return;
 
+    const telegramLinkTab = window.open('', '_blank');
+
     const connect = () => {
       createConnection(undefined, {
         onSuccess: (link: string) => {
-          if (link) window.open(link, '_blank');
+          if (telegramLinkTab) telegramLinkTab.location.href = link;
+        },
+        onError: () => {
+          telegramLinkTab?.close();
         },
       });
     };


### PR DESCRIPTION
https://github.com/xi-effect/xi.progress/issues/127

Исправила открытие ссылки через телеграм:
ранее поведение было: при клике на кнопку мы делали запрос ссылки, затем открывали ее в новом окне. Сафари блокировал данное действие, т.к между пользовательским кликом и открытием нового окна проходило слишком много времени.
новое поведение: при клике сразу открываем пустое окно, а когда приходит ссылка, то перенаправляем в открытое окно. Если по каким-то причинам ссылку не получили, то закрываем окно.

Данная проблема была только на сафари, но логику поставила для всех браузеров, чтобы избежать лишней сложности кода.