### PR TITLE
fix(142): correct validation schema

### DIFF
--- a/packages/features.group.add/src/model/formSchema.ts
+++ b/packages/features.group.add/src/model/formSchema.ts
@@ -2,7 +2,9 @@ import * as z from 'zod';
 
 export const formSchema = z.object({
   name: z.string().min(1, 'Укажите название').max(100, 'Название не должно превышать 100 символов'),
-  subject: z.number().refine((val) => val !== 0, 'Выберите предмет'),
+  subject: z
+    .number({ invalid_type_error: 'Выберите предмет' })
+    .refine((val) => val !== 0, 'Выберите предмет'),
 });
 
 export type FormData = z.infer<typeof formSchema>;

--- a/packages/features.group.add/src/model/formSchema.ts
+++ b/packages/features.group.add/src/model/formSchema.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 export const formSchema = z.object({
   name: z.string().min(1, 'Укажите название').max(100, 'Название не должно превышать 100 символов'),
-  subject: z.number({ required_error: 'Выберите предмет' }),
+  subject: z.number().refine((val) => val !== 0, 'Выберите предмет'),
 });
 
 export type FormData = z.infer<typeof formSchema>;

--- a/packages/features.group.add/src/model/formSchema.ts
+++ b/packages/features.group.add/src/model/formSchema.ts
@@ -2,9 +2,7 @@ import * as z from 'zod';
 
 export const formSchema = z.object({
   name: z.string().min(1, 'Укажите название').max(100, 'Название не должно превышать 100 символов'),
-  subject: z
-    .number({ invalid_type_error: 'Выберите предмет' })
-    .refine((val) => val !== 0, 'Выберите предмет'),
+  subject: z.number().nullable(),
 });
 
 export type FormData = z.infer<typeof formSchema>;

--- a/packages/features.group.add/src/services/useCreateGroup.ts
+++ b/packages/features.group.add/src/services/useCreateGroup.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { handleError } from 'common.services';
 
 export interface CreateGroupRequest {
-  subject_id: number;
+  subject_id: number | null;
   name: string;
 }
 

--- a/packages/features.group.add/src/ui/Autocomplete.tsx
+++ b/packages/features.group.add/src/ui/Autocomplete.tsx
@@ -10,7 +10,7 @@ import { useAutocompleteSubjects, useSubjectsById } from 'common.services';
 import { SubjectSchema } from 'common.api';
 
 type AutocompleteProps = {
-  field: ControllerRenderProps<{ subject: number }, 'subject'>;
+  field: ControllerRenderProps<{ subject: number | null }, 'subject'>;
   disabled?: boolean;
   containerRef?: React.RefObject<HTMLElement | null>;
 };

--- a/packages/features.group.add/src/ui/ModalAddGroup.tsx
+++ b/packages/features.group.add/src/ui/ModalAddGroup.tsx
@@ -27,7 +27,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { formSchema } from '../model';
 import { useCreateGroup } from '../services';
 
-const initialValues = { name: '', subject: 0 };
+const initialValues = { name: '', subject: null };
 
 const cleanupBodyScrollLock = () => {
   document.body.style.overflow = '';


### PR DESCRIPTION
fix: [#142](https://github.com/xi-effect/xi.progress/issues/142)

При попытке создать групповой кабинет бэкенд присылал ошибку, если поле предмет не заполнено. Это происходило из-за неккоректной валидации поля, была проверка только на то, что значение является числом. Значение 0 (состояние пустой строки, когда предмет не выбран) тоже число, но не является валидным для структуры API.

Изменила схему валидации, теперь поле валидно если значение является числом и НЕ равно 0. Кабинет не создается если предмет не выбран.