### PR TITLE
fix(modules.editor): correct dnd for notes elements

### DIFF
--- a/packages/modules.editor/src/config/editorConfig.ts
+++ b/packages/modules.editor/src/config/editorConfig.ts
@@ -56,6 +56,7 @@ export const getExtensions = (
       // Отключаем undoRedo — Collaboration приносит свою реализацию,
       // конфликт двух history-плагинов вызывает infinite update loop
       undoRedo: false,
+
       // Отключаем некоторые расширения, которые будем настраивать отдельно
       horizontalRule: false,
       underline: false, // подключаем Underline отдельно ниже — иначе дубликат имени

--- a/packages/modules.editor/src/extensions/image/ImageNodeView.tsx
+++ b/packages/modules.editor/src/extensions/image/ImageNodeView.tsx
@@ -13,6 +13,7 @@ import { useBlockMenuActions, useYjsContext } from '../../hooks';
 import { cn } from '@xipkg/utils';
 import { useState, useEffect } from 'react';
 import { getAxiosInstance } from 'common.config';
+import { filesApiConfig, FilesQueryKey } from 'common.services';
 
 // Кеш blob URL для уже загруженных изображений (по исходному src)
 const blobUrlCache = new Map<string, string>();
@@ -32,7 +33,12 @@ export const ImageNodeView = ({ node, selected }: NodeViewProps) => {
       }
 
       // Пропускаем data: и blob: URL — они уже пригодны к отображению
-      if (src.startsWith('data:') || src.startsWith('blob:')) {
+      if (
+        src.startsWith('data:') ||
+        src.startsWith('blob:') ||
+        src.startsWith('https') ||
+        src.startsWith('http')
+      ) {
         setImageSrc(src);
         return;
       }
@@ -46,8 +52,11 @@ export const ImageNodeView = ({ node, selected }: NodeViewProps) => {
 
       try {
         // Загружаем изображение с заголовком токена через axios
+        const { getUrl } = filesApiConfig[FilesQueryKey.GetFile];
+        const srcUrl = getUrl(src);
+
         const axiosInst = await getAxiosInstance();
-        const response = await axiosInst.get(src, {
+        const response = await axiosInst.get(srcUrl, {
           responseType: 'blob',
           headers: {
             'x-storage-token': storageToken,

--- a/packages/modules.editor/src/hooks/useBlockMenuActions.ts
+++ b/packages/modules.editor/src/hooks/useBlockMenuActions.ts
@@ -119,16 +119,29 @@ export const useBlockMenuActions = (editor: Editor | null) => {
       return;
     }
 
-    editor.chain().focus().insertContent({ type: 'image', attrs: { src, alt } }).run();
+    editor
+      .chain()
+      .focus()
+      .insertContent({
+        type: 'image',
+        attrs: {
+          src,
+          alt,
+        },
+      })
+      .run();
   };
 
   const downloadImage = (src: string) => {
+    //TODO: downloading is not working
+
     const link = document.createElement('a');
     link.href = src;
     link.download = 'image.png';
     link.click();
   };
 
+  //TODO: moving is not working
   const moveUp = () => moveBlock(editor, 'up');
   const moveDown = () => moveBlock(editor, 'down');
 

--- a/packages/modules.editor/src/ui/components/BlockMenu.tsx
+++ b/packages/modules.editor/src/ui/components/BlockMenu.tsx
@@ -36,7 +36,7 @@ export const BlockMenu = ({ children }: BlockMenuPropsT) => {
       <DropdownMenuContent
         side="right"
         align="start"
-        className="flex w-[200px] flex-col space-y-1 p-2"
+        className="flex w-auto flex-col gap-1 space-y-1 p-2"
       >
         <DropdownMenuItem
           className="hover:bg-gray-5 h-7 gap-2 rounded p-1"

--- a/packages/modules.editor/src/ui/components/BubbleMenuWrapper/BubbleMenuWrapper.tsx
+++ b/packages/modules.editor/src/ui/components/BubbleMenuWrapper/BubbleMenuWrapper.tsx
@@ -14,9 +14,11 @@ interface BubbleMenuProps {
 /** Показывать BubbleMenu только при валидной TextSelection внутри textblock (не doc, не блок без inline). */
 function isValidTextSelectionForBubbleMenu(state: EditorState): boolean {
   const { doc, selection } = state;
+
   if (!(selection instanceof TextSelection) || selection.empty) return false;
   const from = selection.from;
   const to = selection.to;
+
   if (from === 0 || to === 0) return false;
   try {
     const $from = doc.resolve(from);

--- a/packages/modules.editor/src/ui/components/DragHandleWrapper.tsx
+++ b/packages/modules.editor/src/ui/components/DragHandleWrapper.tsx
@@ -11,7 +11,7 @@ export const DragHandleWrapper = ({
   onDragEnd,
 }: {
   editor: Editor;
-  onDragStart: () => void;
+  onDragStart?: () => void;
   onDragEnd: () => void;
   isReadOnly?: boolean;
 }) => {

--- a/packages/modules.editor/src/ui/components/DragHandleWrapper.tsx
+++ b/packages/modules.editor/src/ui/components/DragHandleWrapper.tsx
@@ -19,7 +19,10 @@ export const DragHandleWrapper = ({
     <DragHandle
       editor={editor}
       className="drag-handle"
-      computePositionConfig={{ placement: 'left-start', strategy: 'absolute' }}
+      computePositionConfig={{
+        placement: 'left',
+        strategy: 'absolute',
+      }}
       onElementDragStart={onDragStart}
       onElementDragEnd={onDragEnd}
       nested

--- a/packages/modules.editor/src/ui/components/EditorToolkit.tsx
+++ b/packages/modules.editor/src/ui/components/EditorToolkit.tsx
@@ -11,7 +11,6 @@ type EditorToolkitProps = {
 };
 
 export const EditorToolkit: React.FC<EditorToolkitProps> = ({ editor, isReadOnly }) => {
-  const [isDragging, setIsDragging] = useState(false);
   const [hasMountedDragHandle, setHasMountedDragHandle] = useState(false);
   const initialFixDone = React.useRef(false);
 
@@ -20,13 +19,8 @@ export const EditorToolkit: React.FC<EditorToolkitProps> = ({ editor, isReadOnly
     // Так BubbleMenu не читает невалидный selection и не триггерит предупреждение.
     setTimeout(() => {
       normalizeSelectionAfterDrop(editor);
-      setIsDragging(false);
     }, 0);
   }, [editor]);
-
-  const handleDragStart = useCallback(() => {
-    setIsDragging(true);
-  }, []);
 
   // Проверяем, можно ли показывать тулбар
   const canShowToolbar = !isReadOnly && editor.isEditable !== false;
@@ -56,16 +50,10 @@ export const EditorToolkit: React.FC<EditorToolkitProps> = ({ editor, isReadOnly
             pointerEvents: canShowToolbar ? 'auto' : 'none',
           }}
         >
-          <DragHandleWrapper
-            editor={editor}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            isReadOnly={isReadOnly}
-          />
+          <DragHandleWrapper editor={editor} onDragEnd={handleDragEnd} isReadOnly={isReadOnly} />
         </div>
       )}
-
-      {!isDragging && <BubbleMenuWrapper editor={editor} isReadOnly={isReadOnly} />}
+      <BubbleMenuWrapper editor={editor} isReadOnly={isReadOnly} />
       <ImageUploadModal />
     </>
   );

--- a/packages/modules.editor/src/ui/components/FileUploadDialog.tsx
+++ b/packages/modules.editor/src/ui/components/FileUploadDialog.tsx
@@ -24,13 +24,12 @@ export const ImageUploadModal = () => {
     const file = files[0];
     const optimizedImage = await optimizeImage(file);
     try {
-      const uploadedUrl = await uploadImage({
+      const uploadedId = await uploadImage({
         file: optimizedImage,
         token: storageItem.storage_token,
       });
 
-      insertImage(uploadedUrl);
-
+      insertImage(uploadedId);
       closeModal();
     } catch (err) {
       console.error('Ошибка при загрузке изображения:', err);

--- a/packages/modules.editor/src/ui/components/TiptapEditor.tsx
+++ b/packages/modules.editor/src/ui/components/TiptapEditor.tsx
@@ -1,6 +1,7 @@
 import { EditorContent } from '@tiptap/react';
 import { EditorToolkit } from './EditorToolkit';
 import { useYjsContext } from '../../hooks/useYjsContext';
+
 import '../editor.css';
 
 export const TiptapEditor = () => {

--- a/packages/modules.editor/src/ui/editor.css
+++ b/packages/modules.editor/src/ui/editor.css
@@ -190,7 +190,7 @@
 /* Стили для выделения текста */
 .xi-editor .ProseMirror .ProseMirror-selectednode {
   display: flex;
-  justify-content: center;
+  color: gray;
 }
 
 /* --- Курсоры совместного редактирования (стиль доски / Notion) --- */

--- a/packages/modules.editor/src/ui/editor.css
+++ b/packages/modules.editor/src/ui/editor.css
@@ -138,10 +138,13 @@
   cursor: grab;
   border-radius: 0.25rem;
 }
+
+.ProseMirror:hover + div .drag-handle,
 .xi-editor .drag-handle:hover,
 .xi-editor .drag-handle[data-dragging='true'] {
   opacity: 1;
 }
+
 .xi-editor .drag-handle:active {
   cursor: grabbing;
 }


### PR DESCRIPTION
Элементы не перетаскивались корректно (можно было переместить только один элемент, после чего перетаскивание переставало работать).
Исправлено поведение drag-and-drop, но остался баг в перестаскивании с помощью всплывающего меню или с помощью hot keys