### PR TITLE
fix((modules.profile): add isPending for tg link

### DIFF
--- a/packages/modules.profile/src/services/useConnectTg.ts
+++ b/packages/modules.profile/src/services/useConnectTg.ts
@@ -12,7 +12,7 @@ export const useConnectTg = () => {
   const status = data?.telegram?.connection?.status;
 
   const handleConnectTg = () => {
-    if (status === 'active') return;
+    if (status === 'active' || isPending) return;
 
     const telegramLinkTab = window.open('', '_blank');
 


### PR DESCRIPTION
fix [#138](https://github.com/xi-effect/xi.progress/issues/138)
Попробовала открыть несколько link  при вызове, пробовала повторно вызвать ссылку, повторить баг не удалось. Скорее всего проблема на бэкенде.
Данных хук вызывает только открытие ссылки. Проресерчила с дипсиком, в теории, такая проблема могла быть вызвана из-за нестабильного интернета на момент проверки, напрмер, двойная отправка на бэкенд  с битым ответом. Также при повторной попытке открыть ссылки в боте выводится сообщение, что пользователь ранее уже подключил уведомления.
Для продолжения работы требуется подтверждение бага и инструкция для повтора.

Добавила в хук isPending для защиты от повторных вызовов.

<img width="940" height="1920" alt="eed54d5e-4669-40e5-ae0e-95c75cd5a3f6" src="https://github.com/user-attachments/assets/d9d241b6-5cec-4d92-9d74-a8128244b754" />
