### PR TITLE
fix(modules.board): add emojipicker tool

### DIFF
--- a/packages/modules.board/package.json
+++ b/packages/modules.board/package.json
@@ -17,7 +17,7 @@
     "@xipkg/avatar": "3.3.0",
     "@xipkg/button": "4.1.0",
     "@xipkg/dropdown": "3.0.12",
-    "@xipkg/emojipicker": "1.0.11",
+    "@xipkg/emojipicker": "1.0.12",
     "@xipkg/form": "4.2.2",
     "@xipkg/icons": "^3.0.15",
     "@xipkg/input": "2.0.7",

--- a/packages/modules.board/package.json
+++ b/packages/modules.board/package.json
@@ -17,6 +17,7 @@
     "@xipkg/avatar": "3.3.0",
     "@xipkg/button": "4.1.0",
     "@xipkg/dropdown": "3.0.12",
+    "@xipkg/emojipicker": "1.0.11",
     "@xipkg/form": "4.2.2",
     "@xipkg/icons": "^3.0.15",
     "@xipkg/input": "2.0.7",

--- a/packages/modules.board/src/hooks/useYjsStore.ts
+++ b/packages/modules.board/src/hooks/useYjsStore.ts
@@ -39,6 +39,7 @@ import { BOARD_SCHEMA_VERSION } from '../utils/yjsConstants';
 import { generateUserColor } from '../utils/userColor';
 import { extractFileIdFromUrl } from '../utils/resolveAssetUrl';
 import { XiGeoShapeUtil } from '../shapes/geo';
+import { EmojiShapeUtil } from '../shapes/emoji';
 
 type UseYjsStoreArgs = Partial<{
   hostUrl: string;
@@ -245,6 +246,7 @@ export function useYjsStore({
         PdfShapeUtil,
         AudioShapeUtil,
         XiGeoShapeUtil,
+        EmojiShapeUtil,
         ...shapeUtils,
       ],
       ...(assetStore ? { assets: assetStore } : {}),

--- a/packages/modules.board/src/shapes/emoji/EmojiShapeUtil.tsx
+++ b/packages/modules.board/src/shapes/emoji/EmojiShapeUtil.tsx
@@ -1,0 +1,83 @@
+import { BaseBoxShapeUtil, T, RecordProps, TLBaseShape, HTMLContainer, Rectangle2d } from 'tldraw';
+import { EmojiStyle } from '../shapeStyles';
+import { TEmoji } from '../../types';
+
+export type EmojiShape = TLBaseShape<
+  'emoji',
+  {
+    w: number;
+    h: number;
+    emoji: TEmoji;
+  }
+>;
+
+declare module 'tldraw' {
+  export interface TLGlobalShapePropsMap {
+    emoji: {
+      w: number;
+      h: number;
+      emoji: TEmoji;
+    };
+  }
+}
+
+const EMOJI_BOX_SIZE = 0.7;
+
+export class EmojiShapeUtil extends BaseBoxShapeUtil<EmojiShape> {
+  static override type = 'emoji' as const;
+
+  static override props: RecordProps<EmojiShape> = {
+    w: T.number,
+    h: T.number,
+    emoji: EmojiStyle,
+  };
+
+  override getDefaultProps(): EmojiShape['props'] {
+    return {
+      w: 80,
+      h: 80,
+      emoji: '😀',
+    };
+  }
+
+  override getGeometry(shape: EmojiShape) {
+    return new Rectangle2d({
+      width: shape.props.w,
+      height: shape.props.h,
+      isFilled: true,
+    });
+  }
+
+  override component(shape: EmojiShape) {
+    const { w, h, emoji } = shape.props;
+    const fontSize = Math.min(w, h) * EMOJI_BOX_SIZE;
+
+    return (
+      <HTMLContainer
+        style={{
+          width: w,
+          height: h,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: `${fontSize}px`,
+          fontFamily: 'Apple Color Emoji, Twemoji Mozilla, Noto Color Emoji, Android Emoji',
+        }}
+      >
+        {emoji}
+      </HTMLContainer>
+    );
+  }
+
+  override indicator(shape: EmojiShape) {
+    return <rect width={shape.props.w} height={shape.props.h} />;
+  }
+
+  override isAspectRatioLocked() {
+    return true;
+  }
+
+  override canEdit() {
+    return true;
+  }
+}

--- a/packages/modules.board/src/shapes/emoji/EmojiTool.ts
+++ b/packages/modules.board/src/shapes/emoji/EmojiTool.ts
@@ -1,0 +1,33 @@
+// tools/EmojiTool.ts
+import { StateNode, createShapeId, VecLike } from 'tldraw';
+import { EmojiStyle } from '../shapeStyles';
+
+export class EmojiTool extends StateNode {
+  static override id = 'emoji';
+  static override initial = 'idle';
+
+  private startPoint: VecLike | null = null;
+
+  override onPointerDown() {
+    this.startPoint = {
+      x: this.editor.inputs.currentPagePoint.x,
+      y: this.editor.inputs.currentPagePoint.y,
+    };
+    const size = 80;
+    const emoji = this.editor.getStyleForNextShape(EmojiStyle);
+    const id = createShapeId();
+
+    this.editor.createShape({
+      id,
+      type: 'emoji',
+      x: this.startPoint.x - size / 2,
+      y: this.startPoint.y - size / 2,
+      props: {
+        emoji,
+      },
+    });
+
+    this.editor.setSelectedShapes([id]);
+    this.editor.setCurrentTool('select');
+  }
+}

--- a/packages/modules.board/src/shapes/emoji/index.ts
+++ b/packages/modules.board/src/shapes/emoji/index.ts
@@ -1,0 +1,2 @@
+export { EmojiShapeUtil } from './EmojiShapeUtil';
+export { EmojiTool } from './EmojiTool';

--- a/packages/modules.board/src/shapes/shapeStyles.ts
+++ b/packages/modules.board/src/shapes/shapeStyles.ts
@@ -1,4 +1,4 @@
-import { StyleProp } from 'tldraw';
+import { StyleProp, T } from 'tldraw';
 
 export const BorderColorStyle = StyleProp.defineEnum('xi:borderColor', {
   values: [
@@ -17,4 +17,9 @@ export const BorderColorStyle = StyleProp.defineEnum('xi:borderColor', {
     'yellow',
   ],
   defaultValue: 'black',
+});
+
+export const EmojiStyle = StyleProp.define('xi:emoji', {
+  defaultValue: '😀',
+  type: T.string,
 });

--- a/packages/modules.board/src/store/useTldrawStore.ts
+++ b/packages/modules.board/src/store/useTldrawStore.ts
@@ -62,6 +62,9 @@ interface TldrawState {
   setGeoFillType: (value: string) => void;
   geoBorderThickness: TGeoBorderThickness;
   setGeoBorderThickness: (thickness: TGeoBorderThickness) => void;
+  // emojis
+  recentEmojis: string[];
+  addRecentEmoji: (emoji: string) => void;
 }
 
 export const useTldrawStore = create<TldrawState>()(
@@ -150,6 +153,15 @@ export const useTldrawStore = create<TldrawState>()(
       geoBorderThickness: 'm',
       setGeoBorderThickness: (thickness: TGeoBorderThickness) =>
         set(() => ({ geoBorderThickness: thickness })),
+
+      recentEmojis: [],
+      addRecentEmoji: (emoji) => {
+        if (!emoji) return;
+
+        const { recentEmojis } = get();
+        const emojis = [emoji, ...recentEmojis].slice(0, 8);
+        set(() => ({ recentEmojis: emojis }));
+      },
     }),
     { name: 'tldraw-storage' },
   ),

--- a/packages/modules.board/src/types.ts
+++ b/packages/modules.board/src/types.ts
@@ -23,7 +23,8 @@ export type ToolType =
   | 'asset'
   | 'geo'
   | 'frame'
-  | 'xi-geo';
+  | 'xi-geo'
+  | 'emoji';
 
 export type ElementType =
   | 'line'
@@ -38,7 +39,8 @@ export type ElementType =
   | 'draw'
   | 'geo'
   | 'frame'
-  | 'xi-geo';
+  | 'xi-geo'
+  | 'emoji';
 
 export interface BoardElement {
   id: string;
@@ -85,3 +87,4 @@ export type TDash = (typeof DefaultDashStyle)['defaultValue'];
 export type TFont = (typeof DefaultFontStyle)['defaultValue'];
 export type TAlign = (typeof DefaultTextAlignStyle)['defaultValue'];
 export type TVerticalAlign = (typeof DefaultVerticalAlignStyle)['defaultValue'];
+export type TEmoji = string;

--- a/packages/modules.board/src/ui/components/canvas/TldrawCanvas.tsx
+++ b/packages/modules.board/src/ui/components/canvas/TldrawCanvas.tsx
@@ -21,6 +21,7 @@ import { makeTldrawAssetUrls } from '../../../utils/assetsUrls';
 import { extractFileIdFromUrl } from '../../../utils/resolveAssetUrl';
 import { FrameShapeUtil } from '../../../shapes/frame';
 import { XiGeoShapeUtil, XiGeoTool } from '../../../shapes/geo';
+import { EmojiShapeUtil, EmojiTool } from '../../../shapes/emoji';
 
 export const TldrawCanvas = ({
   token,
@@ -342,13 +343,14 @@ export const TldrawCanvas = ({
             }}
             assetUrls={assetUrls}
             store={store}
-            tools={[XiGeoTool]}
+            tools={[XiGeoTool, EmojiTool]}
             shapeUtils={[
               PdfShapeUtil,
               AudioShapeUtil,
               FrameShapeUtil,
               XiGeoShapeUtil,
               CustomImageShapeUtil,
+              EmojiShapeUtil,
             ]}
             hideUi
             components={{

--- a/packages/modules.board/src/ui/components/shared/ToolPopup.tsx
+++ b/packages/modules.board/src/ui/components/shared/ToolPopup.tsx
@@ -6,11 +6,18 @@ type ToolPopupProps = {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   content: React.ReactNode;
+  isCloseOnOutside?: boolean;
 };
 
-export const ToolPopup = ({ children, open, onOpenChange, content }: ToolPopupProps) => {
+export const ToolPopup = ({
+  children,
+  open,
+  onOpenChange,
+  content,
+  isCloseOnOutside = false,
+}: ToolPopupProps) => {
   const handleEvent = (e: any) => {
-    if (e.target.classList.contains('tl-container')) {
+    if (!isCloseOnOutside && e.target.classList.contains('tl-container')) {
       e.preventDefault();
     }
   };

--- a/packages/modules.board/src/ui/components/toolbar/Navbar.tsx
+++ b/packages/modules.board/src/ui/components/toolbar/Navbar.tsx
@@ -12,12 +12,14 @@ import { navBarElements, NavbarElementT } from '../../../utils/navBarElements';
 import { UndoRedo } from './UndoRedo';
 import { useTldrawStore } from '../../../store';
 import { useTldrawStyles, useHotkeys } from '../../../hooks';
-import { NavbarButton } from '../shared';
+import { NavbarButton, ToolPopup } from '../shared';
 import { ArrowsPopup, PenPopup, StickerPopup } from '../popups';
 import { ShapesPopup } from '../popups/Shapes';
 import { insertImage } from '../../../features/pickAndInsertImage';
 import { insertPdf } from '../../../features/pickAndInsertPdf';
 import { insertAudio, AUDIO_ACCEPT } from '../../../features/pickAndInsertAudio';
+import { EmojiPickerPopup } from '@xipkg/emojipicker';
+import { EmojiStyle } from '../../../shapes/shapeStyles';
 
 // Маппинг инструментов Kanva на Tldraw
 const toolMapping: Record<string, string> = {
@@ -30,6 +32,7 @@ const toolMapping: Record<string, string> = {
   eraser: 'eraser',
   sticker: 'note', // Используем note как аналог стикера
   frame: 'frame',
+  emoji: 'emoji',
   // asset: 'image', // Убираем image, так как его нет в Tldraw
 };
 
@@ -47,7 +50,14 @@ export const Navbar = track(
     canRedo: boolean;
     token: string;
   }) => {
-    const { pencilColor, pencilThickness, pencilOpacity, stickerColor } = useTldrawStore();
+    const {
+      pencilColor,
+      pencilThickness,
+      pencilOpacity,
+      stickerColor,
+      recentEmojis,
+      addRecentEmoji,
+    } = useTldrawStore();
     const { resetToDefaults, setColor, setThickness, setOpacity } = useTldrawStyles();
     const [activePopup, setActivePopup] = React.useState<string | null>(null);
     const editor = useEditor();
@@ -116,6 +126,7 @@ export const Navbar = track(
         eraser: 'eraser',
         note: 'sticker',
         frame: 'frame',
+        emoji: 'emoji',
         // image: 'asset', // Убираем, так как image не существует в Tldraw
       };
 
@@ -139,7 +150,6 @@ export const Navbar = track(
       };
       input.click();
     };
-
     const handleInsertAudio = () => {
       const input = document.createElement('input');
       input.type = 'file';
@@ -299,6 +309,33 @@ export const Navbar = track(
                         className={mobileButtonClass}
                         onClick={() => handleSelectTool(item.action)}
                       />,
+                    );
+                  }
+
+                  if (item.action === 'emoji') {
+                    return wrap(
+                      <ToolPopup
+                        open={isPopupOpen('emoji')}
+                        onOpenChange={(open) => handlePopupToggle('emoji', open)}
+                        isCloseOnOutside
+                        content={
+                          <EmojiPickerPopup
+                            recentEmojis={recentEmojis}
+                            onEmojiSelect={(emoji) => {
+                              editor.setStyleForNextShapes(EmojiStyle, emoji);
+                              addRecentEmoji(emoji);
+                            }}
+                          />
+                        }
+                      >
+                        <NavbarButton
+                          icon={item.icon}
+                          title={item.title}
+                          isActive={isActive}
+                          className={mobileButtonClass}
+                          onClick={() => handleSelectTool(item.action)}
+                        />
+                      </ToolPopup>,
                     );
                   }
 

--- a/packages/modules.board/src/utils/navBarElements.tsx
+++ b/packages/modules.board/src/utils/navBarElements.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import {
   Arrow,
   Cursor,
+  Emotions,
   Eraser,
   Figures,
   Hand,
@@ -99,4 +100,5 @@ export const navBarElements: NavbarElementT[] = [
   { action: 'asset', title: 'Изображение', icon: <Image /> },
   { action: 'eraser', title: 'Ластик', icon: <Eraser /> },
   { action: 'frame', title: 'Фрейм', icon: <Transform /> },
+  { action: 'emoji', title: 'Эмодзи', icon: <Emotions /> },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2910,6 +2910,9 @@ importers:
       '@xipkg/dropdown':
         specifier: 3.0.12
         version: 3.0.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@xipkg/emojipicker':
+        specifier: 1.0.11
+        version: 1.0.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@xipkg/form':
         specifier: 4.2.2
         version: 4.2.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8939,6 +8942,11 @@ packages:
     peerDependencies:
       react: ^19
 
+  '@xipkg/emojipicker@1.0.11':
+    resolution: {integrity: sha512-jW/Jr2FeI5KVYbCUa5U4hlYHbfPV/2NU0vlTbNHS3B1he0mMJGxFCi1ogZ7UiMWsPTvVLCvckDrToCZLl61c2A==}
+    peerDependencies:
+      react: ^19
+
   '@xipkg/eslint@3.2.0':
     resolution: {integrity: sha512-ZzUkhFj4MYc5s5DPu5JeGHaccM+eMoNwHaSnVfBMprkbI34nC579e1nkYP8YG3LoEgfCi5DVA581jEVpyY4YZw==}
 
@@ -9585,6 +9593,9 @@ packages:
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
+  emoji-mart@5.6.0:
+    resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -9699,8 +9710,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-config-turbo@2.9.9:
-    resolution: {integrity: sha512-KhO8N8ot1s9wXbkNDVgMwvkpbfO+YgEbteikFu406aQoJgenzNh5ErI985CeFKV3e33ZGLZX5YAJ1pgnhOXCZA==}
+  eslint-config-turbo@2.9.14:
+    resolution: {integrity: sha512-8bAXNDwtmHV7CuSDX+FB9+TslZEP8qJoNWY9FQTEhyO42bRimcExxwOh1+K2H2JV2VFXJrkt1KxyJmy2xm8Ukw==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -9790,14 +9801,14 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-turbo@2.9.8:
-    resolution: {integrity: sha512-czP2GjPzR6G+BpVEKXNa7Vs45/Zz0QjUEyB+SSLNpVJTqBe331AlE9IxkC2Eh00H6a1hf/Q6BVwf+1WJupyVYA==}
+  eslint-plugin-turbo@2.9.14:
+    resolution: {integrity: sha512-ROTlsO1JBJLATxtDNd7t22vviSb0hD8fKnjOO0WRgtxJW3VBRNO3BLAC129GPZSvEvtMH/f71Y2TzrqGPjLpEw==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
 
-  eslint-plugin-turbo@2.9.9:
-    resolution: {integrity: sha512-CHjV79PUXv5D+eCcnk3IMfu15X+EnwDSOWcVM72gQ3Ib8J+pF6zrY7A0kOgdS2HexdaGDoqzSLiXYRyu42TaGQ==}
+  eslint-plugin-turbo@2.9.8:
+    resolution: {integrity: sha512-czP2GjPzR6G+BpVEKXNa7Vs45/Zz0QjUEyB+SSLNpVJTqBe331AlE9IxkC2Eh00H6a1hf/Q6BVwf+1WJupyVYA==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -15668,13 +15679,29 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
+  '@xipkg/emojipicker@1.0.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@xipkg/button': 3.2.0(@types/react@19.2.14)(react@19.2.5)
+      '@xipkg/dropdown': 3.0.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@xipkg/icons': 2.7.2(react@19.2.5)
+      '@xipkg/input': 2.2.9(react@19.2.5)
+      '@xipkg/tooltip': 2.1.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@xipkg/utils': 1.8.0(react@19.2.5)
+      class-variance-authority: 0.7.1
+      emoji-mart: 5.6.0
+      react: 19.2.5
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
   '@xipkg/eslint@3.2.0(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3)
-      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-hooks@5.1.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react@7.37.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-hooks@5.1.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react@7.37.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-config-next: 15.1.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3)
       eslint-config-prettier: 9.1.0(eslint@9.39.4(jiti@2.6.1))
-      eslint-config-turbo: 2.9.9(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8)
+      eslint-config-turbo: 2.9.14(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.39.4(jiti@2.6.1))
@@ -16492,6 +16519,8 @@ snapshots:
 
   electron-to-chromium@1.5.349: {}
 
+  emoji-mart@5.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -16659,7 +16688,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 9.39.4(jiti@2.6.1)
@@ -16668,10 +16697,10 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
-  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-hooks@5.1.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react@7.37.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react-hooks@5.1.0(eslint@9.39.4(jiti@2.6.1)))(eslint-plugin-react@7.37.2(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.2(eslint@9.39.4(jiti@2.6.1))
@@ -16687,7 +16716,7 @@ snapshots:
       '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -16707,10 +16736,10 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
 
-  eslint-config-turbo@2.9.9(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8):
+  eslint-config-turbo@2.9.14(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
-      eslint-plugin-turbo: 2.9.9(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8)
+      eslint-plugin-turbo: 2.9.14(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8)
       turbo: 2.9.8
 
   eslint-import-resolver-node@0.3.10:
@@ -16721,7 +16750,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -16736,14 +16765,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -16758,7 +16787,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16853,13 +16882,13 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-turbo@2.9.8(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8):
+  eslint-plugin-turbo@2.9.14(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.39.4(jiti@2.6.1)
       turbo: 2.9.8
 
-  eslint-plugin-turbo@2.9.9(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8):
+  eslint-plugin-turbo@2.9.8(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.8):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.39.4(jiti@2.6.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2911,8 +2911,8 @@ importers:
         specifier: 3.0.12
         version: 3.0.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@xipkg/emojipicker':
-        specifier: 1.0.11
-        version: 1.0.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 1.0.12
+        version: 1.0.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@xipkg/form':
         specifier: 4.2.2
         version: 4.2.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8942,8 +8942,8 @@ packages:
     peerDependencies:
       react: ^19
 
-  '@xipkg/emojipicker@1.0.11':
-    resolution: {integrity: sha512-jW/Jr2FeI5KVYbCUa5U4hlYHbfPV/2NU0vlTbNHS3B1he0mMJGxFCi1ogZ7UiMWsPTvVLCvckDrToCZLl61c2A==}
+  '@xipkg/emojipicker@1.0.12':
+    resolution: {integrity: sha512-RTDWPbJ8Nr/AnWE/n1rV1/TQLZ7U0JFjVwXJxDj9EorEYXJfwcPjbagw6vHd0jvCsdudjVbG0hhKgpa2lQUzMA==}
     peerDependencies:
       react: ^19
 
@@ -15679,7 +15679,7 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@xipkg/emojipicker@1.0.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@xipkg/emojipicker@1.0.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@xipkg/button': 3.2.0(@types/react@19.2.14)(react@19.2.5)
       '@xipkg/dropdown': 3.0.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
fix [#132](https://github.com/xi-effect/xi.progress/issues/132)
Добавлен новый инструмент emojipicker на доску.
В recentEmojis сохраняются 8 ранее использованных эмодзи.  Эмодзи можно вращать, изменять размер, копирование, удаление и блокировка работают стандартно. Значение ранее выбранного стикера в стейт не сохраняется, нужно ли это поведение, вопрос на обсуждение. При выборе инструмента эмодзи будет тот, что по умолчанию.