### PR TITLE
fix(pages.calendar & pages.classroom):   #156

### DIFF
--- a/packages/pages.classroom/src/ui/Overview/UpcomingLessonsSection.tsx
+++ b/packages/pages.classroom/src/ui/Overview/UpcomingLessonsSection.tsx
@@ -215,7 +215,7 @@ export const UpcomingLessonsSection = () => {
               <div className="flex min-h-[220px] w-max flex-row items-stretch gap-4 pr-1 pb-4">
                 {lessons.map(({ lesson, item }, index) => (
                   <UpcomingLessonCard
-                    key={`${lesson.classroomId}-${lesson.startAt?.toISOString()}`}
+                    key={`${lesson.id}`}
                     lesson={lesson}
                     classroomId={classroomId}
                     isNearest={index === 0}


### PR DESCRIPTION
На странице ближайших занятий исправлена ошибка в консоли о дублирующихся ключах.
Теперь в качестве ключа для карточки запланированного занятия используется lesson.id